### PR TITLE
Fixed eventually missing global Engine variable

### DIFF
--- a/LuaUI/widgets/gui_chili_selections_and_cursortip.lua
+++ b/LuaUI/widgets/gui_chili_selections_and_cursortip.lua
@@ -61,6 +61,9 @@ VFS.Include("LuaRules/Configs/customcmds.h.lua")
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+if Engine == nil then
+	Engine = Game
+end
 local reverseCompat = (Engine.version:find('91.0') == 1) and 1 or 0
 
 local Chili


### PR DESCRIPTION
A small bug fix. In Spring-103 it is breaking the tooltips (tested in BA and S44)