### PR TITLE
Added the liblobby dependency as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/liblobby"]
+	path = libs/liblobby
+	url = https://github.com/gajop/liblobby.git

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ The production version can be obtained from rapid, via:
 `pr-downloader sbc:test`
 
 The development version can be obtained from this repository, by cloning it in your game folder:
-`git clone https://github.com/Spring-SpringBoard/SpringBoard-Core SB-C.sdd`
+```
+git clone https://github.com/Spring-SpringBoard/SpringBoard-Core SB-C.sdd
+cd SB-C.sdd
+git submodule init
+git submodule update
+```
 
 ### Game-specific modules
 This is the core module, you may still want to get additional game-specific modules if you're making a scenario.


### PR DESCRIPTION
I actually don't know if liblobby is required. Anyway, the api_lobby.lua widget error can be easily fixed by adding a git submodule
Along this line, I think in general the libs subfolder should be feeded using git submodules

If liblobby is useless, please feel free to close this PR, and remove api_lobby.lua by yourself